### PR TITLE
bugfix: added missing golden kubestrong label

### DIFF
--- a/users.json
+++ b/users.json
@@ -468,6 +468,7 @@
     "name": "Insu Kim",
     "github": "ahinsutime",
     "certs": [
+      "golden kubestrong",
       "kubestrong",
       "golden kubestronaut",
       "kubestronaut"


### PR DESCRIPTION
- Added missing `golden kubestrong` label from Insu Kim's section at `user.json` file.